### PR TITLE
Thin user controller auth flows

### DIFF
--- a/lib/streamshore/accounts.ex
+++ b/lib/streamshore/accounts.ex
@@ -150,6 +150,14 @@ defmodule Streamshore.Accounts do
     )
   end
 
+  def list_users_for(user, anon) do
+    if !anon and admin?(user) do
+      {:ok, list_users()}
+    else
+      {:error, :forbidden}
+    end
+  end
+
   def create_user(params) do
     params =
       if Mailer.enabled?() do
@@ -252,6 +260,14 @@ defmodule Streamshore.Accounts do
     update_user(username, &User.password_changeset(&1, %{password: password}))
   end
 
+  def update_password_for(user, anon, username, password) do
+    if !anon and authorized_to_update_password?(user, username) do
+      update_password(username, password)
+    else
+      {:error, :forbidden}
+    end
+  end
+
   def delete_user(username) do
     case Repo.get_by(User, username: username) do
       nil ->
@@ -283,6 +299,14 @@ defmodule Streamshore.Accounts do
           {:error, _step, changeset, _changes} ->
             {:error, changeset}
         end
+    end
+  end
+
+  def delete_user_for(user, anon, username) do
+    if !anon and user == username do
+      delete_user(username)
+    else
+      {:error, :forbidden}
     end
   end
 
@@ -319,6 +343,10 @@ defmodule Streamshore.Accounts do
           (f.friender == ^friender and f.friendee == ^friendee) or
             (f.friender == ^friendee and f.friendee == ^friender)
     )
+  end
+
+  defp authorized_to_update_password?(user, username) do
+    user == username || user == "Reset-" <> username
   end
 
   defp accept_friend_request(relation, friender, friendee) do

--- a/lib/streamshore_web/controllers/user_controller.ex
+++ b/lib/streamshore_web/controllers/user_controller.ex
@@ -11,11 +11,13 @@ defmodule StreamshoreWeb.UserController do
       {:error, error} ->
         ApiResponses.error(conn, :unauthorized, error)
 
-      {:ok, _user, _anon, admin} ->
-        if admin do
-          ApiResponses.ok(conn, Accounts.list_users())
-        else
-          ApiResponses.error(conn, :forbidden, "Insufficient permission")
+      {:ok, user, anon, _admin} ->
+        case Accounts.list_users_for(user, anon) do
+          {:ok, users} ->
+            ApiResponses.ok(conn, users)
+
+          {:error, :forbidden} ->
+            ApiResponses.error(conn, :forbidden, "Insufficient permission")
         end
     end
   end
@@ -63,22 +65,19 @@ defmodule StreamshoreWeb.UserController do
   def delete(conn, params) do
     case Guardian.get_user(Guardian.token_from_conn(conn)) do
       {:ok, user, anon} ->
-        username = params["id"]
+        case Accounts.delete_user_for(user, anon, params["id"]) do
+          {:ok, _schema, events} ->
+            Events.dispatch_all(events)
+            ApiResponses.ok(conn)
 
-        if user == username && !anon do
-          case Accounts.delete_user(username) do
-            {:ok, _schema, events} ->
-              Events.dispatch_all(events)
-              ApiResponses.ok(conn)
+          {:error, :forbidden} ->
+            ApiResponses.error(conn, :forbidden, "Insufficient permission")
 
-            {:error, :not_found} ->
-              ApiResponses.error(conn, :not_found, "User not found")
+          {:error, :not_found} ->
+            ApiResponses.error(conn, :not_found, "User not found")
 
-            {:error, changeset} ->
-              ApiResponses.changeset_error(conn, changeset)
-          end
-        else
-          ApiResponses.error(conn, :forbidden, "Insufficient permission")
+          {:error, changeset} ->
+            ApiResponses.changeset_error(conn, changeset)
         end
 
       {:error, error} ->
@@ -139,25 +138,18 @@ defmodule StreamshoreWeb.UserController do
         ApiResponses.error(conn, :unauthorized, error)
 
       {:ok, user, anon} ->
-        username = params["id"]
+        case Accounts.update_password_for(user, anon, params["id"], params["password"]) do
+          {:ok, _schema} ->
+            ApiResponses.ok(conn)
 
-        if !anon do
-          if user == username || user == "Reset-" <> username do
-            case Accounts.update_password(username, params["password"]) do
-              {:ok, _schema} ->
-                ApiResponses.ok(conn)
-
-              {:error, :not_found} ->
-                ApiResponses.error(conn, :not_found, "User not found")
-
-              {:error, changeset} ->
-                ApiResponses.changeset_error(conn, changeset)
-            end
-          else
+          {:error, :forbidden} ->
             ApiResponses.error(conn, :forbidden, "Insufficient permission")
-          end
-        else
-          ApiResponses.error(conn, :forbidden, "Insufficient permission")
+
+          {:error, :not_found} ->
+            ApiResponses.error(conn, :not_found, "User not found")
+
+          {:error, changeset} ->
+            ApiResponses.changeset_error(conn, changeset)
         end
     end
   end

--- a/test/streamshore/accounts_test.exs
+++ b/test/streamshore/accounts_test.exs
@@ -132,6 +132,48 @@ defmodule Streamshore.AccountsTest do
     assert Repo.get_by!(User, username: "password-user").reset_token == nil
   end
 
+  test "update_password_for allows the matching user" do
+    assert {:ok, _user, _events} =
+             Accounts.create_user(%{
+               "email" => "password@test.com",
+               "username" => "password-user",
+               "password" => "$Test123"
+             })
+
+    assert {:ok, updated_user} =
+             Accounts.update_password_for("password-user", false, "password-user", "$NewPass123")
+
+    assert updated_user.password != "$NewPass123"
+  end
+
+  test "update_password_for allows the reset token subject" do
+    assert {:ok, _user, _events} =
+             Accounts.create_user(%{
+               "email" => "password@test.com",
+               "username" => "password-user",
+               "password" => "$Test123"
+             })
+
+    assert {:ok, updated_user} =
+             Accounts.update_password_for(
+               "Reset-password-user",
+               false,
+               "password-user",
+               "$NewPass123"
+             )
+
+    assert updated_user.password != "$NewPass123"
+  end
+
+  test "update_password_for rejects unauthorized users" do
+    assert {:error, :forbidden} =
+             Accounts.update_password_for("other-user", false, "password-user", "$NewPass123")
+  end
+
+  test "list_users_for rejects non-admin users" do
+    assert {:error, :forbidden} = Accounts.list_users_for("user", false)
+  end
+
   test "delete_user removes owned room references" do
     assert {:ok, _user, _events} =
              Accounts.create_user(%{
@@ -164,6 +206,10 @@ defmodule Streamshore.AccountsTest do
     assert Repo.get_by(Room, route: room.route) == nil
     assert Repo.get_by(Favorites, room: room.route) == nil
     assert Repo.get_by(Permission, room: room.route) == nil
+  end
+
+  test "delete_user_for rejects mismatched users" do
+    assert {:error, :forbidden} = Accounts.delete_user_for("other-user", false, "owner-user")
   end
 
   test "create_favorite stores the room route for the user" do


### PR DESCRIPTION
## Summary
- move user-list, password-update, and delete-user authorization checks behind `Streamshore.Accounts`
- keep `UserController` focused on request routing and HTTP response mapping
- add focused `Accounts` tests for the moved authorization behavior

## Testing
- `mix test test/streamshore/accounts_test.exs test/streamshore_web/controllers/user_controller_test.exs`
- `mix test`