### PR TITLE
Move auth and permission checks behind plugs and contexts

### DIFF
--- a/lib/streamshore/accounts.ex
+++ b/lib/streamshore/accounts.ex
@@ -1,4 +1,5 @@
 defmodule Streamshore.Accounts do
+  import Dictionary
   import Ecto.Query
 
   alias Ecto.Multi
@@ -178,6 +179,27 @@ defmodule Streamshore.Accounts do
     end
   end
 
+  def create_authenticated_session(identifier, password) do
+    with user when not is_nil(user) <- get_by_email_or_username(identifier),
+         true <- Pbkdf2.verify_pass(password, user.password),
+         :ok <- ensure_verified(user) do
+      {:ok, session_payload(user.username, false)}
+    else
+      nil ->
+        {:error, :invalid_credentials}
+
+      false ->
+        {:error, :invalid_credentials}
+
+      {:error, :email_not_verified} ->
+        {:error, :email_not_verified}
+    end
+  end
+
+  def create_anonymous_session do
+    {:ok, session_payload(build_anonymous_username(), true)}
+  end
+
   def resend_verification_email(id) do
     case get_by_email_or_username(id) do
       nil ->
@@ -238,8 +260,8 @@ defmodule Streamshore.Accounts do
     end
   end
 
-  def store_reset_token(email) do
-    case get_by_email(email) do
+  def request_password_reset(identifier) do
+    case get_by_email_or_username(identifier) do
       nil ->
         {:error, :not_found}
 
@@ -256,10 +278,16 @@ defmodule Streamshore.Accounts do
     end
   end
 
-  def valid_reset_token?(username, token) do
+  def reset_password(username, reset_token, password) do
     case Repo.get_by(User, username: username) do
-      %User{reset_token: ^token} when not is_nil(token) -> true
-      _ -> false
+      nil ->
+        {:error, :not_found}
+
+      %User{reset_token: ^reset_token} when not is_nil(reset_token) ->
+        update_password(username, password)
+
+      %User{} ->
+        {:error, :invalid_token}
     end
   end
 
@@ -315,6 +343,23 @@ defmodule Streamshore.Accounts do
         |> changeset_fun.()
         |> Repo.update()
     end
+  end
+
+  defp ensure_verified(%{verify_token: nil}), do: :ok
+  defp ensure_verified(_user), do: {:error, :email_not_verified}
+
+  defp session_payload(username, anonymous?) do
+    %{
+      token: AuthTokens.create_token(username, anonymous?),
+      user: username,
+      anon: anonymous?
+    }
+  end
+
+  defp build_anonymous_username do
+    String.capitalize(String.trim(random_adjective(), "\r")) <>
+      String.capitalize(String.trim(random_adjective(), "\r")) <>
+      String.capitalize(String.trim(random_animal(), "\r"))
   end
 
   defp normalize_room_identifier(room_identifier) when is_binary(room_identifier) do

--- a/lib/streamshore/events.ex
+++ b/lib/streamshore/events.ex
@@ -14,6 +14,10 @@ defmodule Streamshore.Events do
     RoomEvents.dispatch({:room_updated, route, payload})
   end
 
+  def dispatch({:permission_updated, route, payload}) do
+    RoomEvents.dispatch({:permission_updated, route, payload})
+  end
+
   def dispatch({:send_verification_email, user}) do
     AccountEvents.dispatch({:send_verification_email, user})
   end

--- a/lib/streamshore/guardian.ex
+++ b/lib/streamshore/guardian.ex
@@ -1,9 +1,6 @@
 defmodule Streamshore.Guardian do
   use Guardian, otp_app: :streamshore
 
-  alias Streamshore.Accounts
-  alias Streamshore.Rooms
-
   def subject_for_token(user, _claims) do
     sub = to_string(user)
     {:ok, sub}
@@ -22,56 +19,6 @@ defmodule Streamshore.Guardian do
          end) do
       {_, "Bearer " <> token} -> token
       _ -> nil
-    end
-  end
-
-  def get_user(token) do
-    case token do
-      nil ->
-        {:error, "No valid token provided"}
-
-      token ->
-        case decode_and_verify(token) do
-          {:error, _error} ->
-            {:error, "Invalid token"}
-
-          {:ok, claims} ->
-            {:ok, claims["sub"], claims["anon"]}
-        end
-    end
-  end
-
-  def get_user_and_permission(token, room) do
-    case token do
-      nil ->
-        {:error, "No valid token provided"}
-
-      token ->
-        case get_user(token) do
-          {:error, error} ->
-            {:error, error}
-
-          {:ok, user, anon} ->
-            perm = Rooms.get_permission(room, user)
-            {:ok, user, anon, perm}
-        end
-    end
-  end
-
-  def get_user_and_admin(token) do
-    case token do
-      nil ->
-        {:error, "No valid token provided"}
-
-      token ->
-        case get_user(token) do
-          {:error, error} ->
-            {:error, error}
-
-          {:ok, user, anon} ->
-            admin = Accounts.admin?(user)
-            {:ok, user, anon, admin}
-        end
     end
   end
 end

--- a/lib/streamshore/rooms.ex
+++ b/lib/streamshore/rooms.ex
@@ -40,7 +40,7 @@ defmodule Streamshore.Rooms do
     Multi.new()
     |> Multi.insert(:room, Room.changeset(%Room{}, attrs))
     |> Multi.run(:permission, fn _repo, %{room: room} ->
-      update_permission(room.route, owner, PermissionLevel.owner())
+      update_permission_internal(room.route, owner, PermissionLevel.owner())
     end)
     |> Repo.transaction()
     |> case do
@@ -69,24 +69,18 @@ defmodule Streamshore.Rooms do
     end
   end
 
-  def delete_owned_room(room, owner) do
-    case Repo.get_by(Room, route: room) do
-      nil ->
+  def delete_room(room) do
+    case room
+         |> single_room_scope()
+         |> run_room_deletion() do
+      {:ok, [room_route], events} ->
+        {:ok, room_route, events}
+
+      {:ok, [], _events} ->
         {:error, :not_found}
 
-      %Room{owner: ^owner} = schema ->
-        case schema
-             |> single_room_scope()
-             |> run_room_deletion() do
-          {:ok, _room_routes, events} ->
-            {:ok, schema, events}
-
-          {:error, changeset} ->
-            {:error, changeset}
-        end
-
-      %Room{} ->
-        {:error, :forbidden}
+      {:error, changeset} ->
+        {:error, changeset}
     end
   end
 
@@ -116,8 +110,8 @@ defmodule Streamshore.Rooms do
   def list_permissions(room) do
     query =
       from p in Permission,
-           where: [room: ^room],
-           select: %{user: p.username, permission: p.permission}
+        where: [room: ^room],
+        select: %{user: p.username, permission: p.permission}
 
     Repo.all(query)
   end
@@ -130,6 +124,23 @@ defmodule Streamshore.Rooms do
   end
 
   def update_permission(room, user, permission) do
+    case update_permission_internal(room, user, permission) do
+      {:ok, updated_permission} ->
+        {:ok, updated_permission,
+          [
+            {:permission_updated, room,
+              %{
+                user: user,
+                permission: permission
+              }}
+          ]}
+
+      {:error, changeset} ->
+        {:error, changeset}
+    end
+  end
+
+  defp update_permission_internal(room, user, permission) do
     case Repo.get_by(Permission, room: room, username: user) do
       nil -> %Permission{room: room, username: user}
       permission -> permission
@@ -265,7 +276,7 @@ defmodule Streamshore.Rooms do
   end
 
   defp single_room_scope(room) do
-    from(r in Room, where: r.id == ^room.id)
+    from(r in Room, where: r.route == ^room)
   end
 
   defp room_updated_event(room, attrs) do

--- a/lib/streamshore_web/controllers/favorite_controller.ex
+++ b/lib/streamshore_web/controllers/favorite_controller.ex
@@ -2,89 +2,48 @@ defmodule StreamshoreWeb.FavoriteController do
   use StreamshoreWeb, :controller
 
   alias Streamshore.Accounts
-  alias Streamshore.Guardian
   alias StreamshoreWeb.ApiResponses
   alias StreamshoreWeb.Presence
 
-  def index(conn, params) do
-    params["user_id"]
+  plug StreamshoreWeb.Plugs.RequireAuth
+  plug StreamshoreWeb.Plugs.RequireNonAnon
+  plug StreamshoreWeb.Plugs.RequireCurrentUser, param: "user_id"
+
+  def index(conn, _params) do
+    conn.assigns.current_user
     |> Accounts.list_favorite_rooms()
     |> with_user_counts()
     |> then(&ApiResponses.ok(conn, &1))
   end
 
   def show(conn, params) do
-    favorite = Accounts.favorite?(params["user_id"], params["id"])
+    favorite = Accounts.favorite?(conn.assigns.current_user, params["id"])
     ApiResponses.ok(conn, favorite)
   end
 
   def create(conn, params) do
-    case Guardian.get_user(Guardian.token_from_conn(conn)) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    case Accounts.create_favorite(conn.assigns.current_user, params["room"]) do
+      {:ok, _schema} ->
+        ApiResponses.ok(conn)
 
-      {:ok, current_user, anon} ->
-        room = params["room"]
-        user = params["user_id"]
+      {:error, :room_not_found} ->
+        ApiResponses.error(conn, :not_found, "Room does not exist")
 
-        cond do
-          anon ->
-            ApiResponses.error(
-              conn,
-              :forbidden,
-              "You must be logged in to add a room to favorites"
-            )
-
-          current_user != user ->
-            ApiResponses.error(conn, :forbidden, "Insufficient permission")
-
-          true ->
-            case Accounts.create_favorite(user, room) do
-              {:ok, _schema} ->
-                ApiResponses.ok(conn)
-
-              {:error, :room_not_found} ->
-                ApiResponses.error(conn, :not_found, "Room does not exist")
-
-              {:error, changeset} ->
-                ApiResponses.changeset_error(conn, changeset)
-            end
-        end
+      {:error, changeset} ->
+        ApiResponses.changeset_error(conn, changeset)
     end
   end
 
   def delete(conn, params) do
-    case Guardian.get_user(Guardian.token_from_conn(conn)) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    case Accounts.delete_favorite(conn.assigns.current_user, params["id"]) do
+      {:ok, _schema} ->
+        ApiResponses.ok(conn)
 
-      {:ok, current_user, anon} ->
-        room = params["id"]
-        user = params["user_id"]
+      {:error, :not_found} ->
+        ApiResponses.error(conn, :not_found, "Favorite does not exist")
 
-        cond do
-          anon ->
-            ApiResponses.error(
-              conn,
-              :forbidden,
-              "You must be logged in to remove a room from favorites"
-            )
-
-          current_user != user ->
-            ApiResponses.error(conn, :forbidden, "Insufficient permission")
-
-          true ->
-            case Accounts.delete_favorite(user, room) do
-              {:error, :not_found} ->
-                ApiResponses.error(conn, :not_found, "Favorite does not exist")
-
-              {:ok, _schema} ->
-                ApiResponses.ok(conn)
-
-              {:error, changeset} ->
-                ApiResponses.changeset_error(conn, changeset)
-            end
-        end
+      {:error, changeset} ->
+        ApiResponses.changeset_error(conn, changeset)
     end
   end
 

--- a/lib/streamshore_web/controllers/friend_controller.ex
+++ b/lib/streamshore_web/controllers/friend_controller.ex
@@ -2,105 +2,54 @@ defmodule StreamshoreWeb.FriendController do
   use StreamshoreWeb, :controller
 
   alias Streamshore.Accounts
-  alias Streamshore.Guardian
   alias StreamshoreWeb.ApiResponses
 
-  def index(conn, params) do
-    params["user_id"]
+  plug StreamshoreWeb.Plugs.RequireAuth
+  plug StreamshoreWeb.Plugs.RequireNonAnon
+  plug StreamshoreWeb.Plugs.RequireCurrentUser, param: "user_id"
+
+  def index(conn, _params) do
+    conn.assigns.current_user
     |> Accounts.list_friendships()
     |> then(&ApiResponses.ok(conn, &1))
   end
 
   def create(conn, params) do
-    case Guardian.get_user(Guardian.token_from_conn(conn)) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    case Accounts.create_friend_request(conn.assigns.current_user, params["friendee"]) do
+      {:ok, _schema} ->
+        ApiResponses.ok(conn)
 
-      {:ok, user, anon} ->
-        friender = params["user_id"]
-        friendee = params["friendee"]
+      {:error, :user_not_found} ->
+        ApiResponses.error(conn, :not_found, "User does not exist")
 
-        cond do
-          anon ->
-            ApiResponses.error(conn, :forbidden, "You must be logged in to add a friend")
+      {:error, :already_exists} ->
+        ApiResponses.error(conn, :conflict, "Friend connection already exists")
 
-          user != friender ->
-            ApiResponses.error(conn, :forbidden, "Insufficient permission")
-
-          true ->
-            case Accounts.create_friend_request(friender, friendee) do
-              {:ok, _schema} ->
-                ApiResponses.ok(conn)
-
-              {:error, :user_not_found} ->
-                ApiResponses.error(conn, :not_found, "User does not exist")
-
-              {:error, :already_exists} ->
-                ApiResponses.error(conn, :conflict, "Friend connection already exists")
-
-              {:error, changeset} ->
-                ApiResponses.changeset_error(conn, changeset)
-            end
-        end
+      {:error, changeset} ->
+        ApiResponses.changeset_error(conn, changeset)
     end
   end
 
   def update(conn, params) do
-    case Guardian.get_user(Guardian.token_from_conn(conn)) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    case Accounts.update_friendship(conn.assigns.current_user, params["id"], params) do
+      {:ok, _schema} ->
+        ApiResponses.ok(conn)
 
-      {:ok, user, anon} ->
-        friender = params["user_id"]
-        friendee = params["id"]
+      {:error, :not_found} ->
+        ApiResponses.error(conn, :not_found, "Friendship not found")
 
-        cond do
-          anon ->
-            ApiResponses.error(conn, :forbidden, "You must be logged in to update a friendship")
-
-          user != friender ->
-            ApiResponses.error(conn, :forbidden, "Insufficient permission")
-
-          true ->
-            case Accounts.update_friendship(friender, friendee, params) do
-              {:ok, _schema} ->
-                ApiResponses.ok(conn)
-
-              {:error, :not_found} ->
-                ApiResponses.error(conn, :not_found, "Friendship not found")
-
-              {:error, changeset} ->
-                ApiResponses.changeset_error(conn, changeset)
-            end
-        end
+      {:error, changeset} ->
+        ApiResponses.changeset_error(conn, changeset)
     end
   end
 
   def delete(conn, params) do
-    case Guardian.get_user(Guardian.token_from_conn(conn)) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    case Accounts.delete_friendship(conn.assigns.current_user, params["id"]) do
+      :ok ->
+        ApiResponses.ok(conn)
 
-      {:ok, user, anon} ->
-        friender = params["user_id"]
-        friendee = params["id"]
-
-        cond do
-          anon ->
-            ApiResponses.error(conn, :forbidden, "You must be logged in to delete a friendship")
-
-          user != friender ->
-            ApiResponses.error(conn, :forbidden, "Insufficient permission")
-
-          true ->
-            case Accounts.delete_friendship(friender, friendee) do
-              :ok ->
-                ApiResponses.ok(conn)
-
-              {:error, changeset} ->
-                ApiResponses.changeset_error(conn, changeset)
-            end
-        end
+      {:error, changeset} ->
+        ApiResponses.changeset_error(conn, changeset)
     end
   end
 end

--- a/lib/streamshore_web/controllers/permission_controller.ex
+++ b/lib/streamshore_web/controllers/permission_controller.ex
@@ -1,47 +1,42 @@
 defmodule StreamshoreWeb.PermissionController do
   use StreamshoreWeb, :controller
 
-  alias Streamshore.Guardian
+  alias Streamshore.Events
   alias Streamshore.PermissionLevel
   alias Streamshore.Rooms
   alias StreamshoreWeb.ApiResponses
 
+  plug StreamshoreWeb.Plugs.RequireAuth
+  plug StreamshoreWeb.Plugs.LoadRoomPermission when action in [:update]
+
+  plug StreamshoreWeb.Plugs.RequireRoomPermission,
+       [min: PermissionLevel.manager()] when action in [:update]
+
   def index(conn, params) do
-    room = params["room_id"]
-    perms = Rooms.list_permissions(room)
-    ApiResponses.ok(conn, perms)
+    Rooms.list_permissions(params["room_id"])
+    |> then(&ApiResponses.ok(conn, &1))
   end
 
   def show(conn, params) do
-    perm = Rooms.get_permission(params["room_id"], params["id"])
-    ApiResponses.ok(conn, perm)
+    Rooms.get_permission(params["room_id"], params["id"])
+    |> then(&ApiResponses.ok(conn, &1))
   end
 
   def update(conn, params) do
-    room = params["room_id"]
-    user = params["id"]
-    perm = params["permission"]
+    permission = params["permission"]
 
-    case Guardian.get_user_and_permission(Guardian.token_from_conn(conn), params["room_id"]) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    cond do
+      conn.assigns.current_room_permission <= permission ->
+        ApiResponses.error(conn, :forbidden, "Insufficient permission")
 
-      {:ok, _user, _anon, permission} ->
-        if permission > perm && permission >= PermissionLevel.manager() do
-          case Rooms.update_permission(room, user, perm) do
-            {:ok, _schema} ->
-              StreamshoreWeb.Endpoint.broadcast("room:" <> room, "permission", %{
-                user: user,
-                permission: perm
-              })
+      true ->
+        case Rooms.update_permission(params["room_id"], params["id"], permission) do
+          {:ok, _schema, events} ->
+            Events.dispatch_all(events)
+            ApiResponses.ok(conn)
 
-              ApiResponses.ok(conn)
-
-            {:error, changeset} ->
-              ApiResponses.changeset_error(conn, changeset)
-          end
-        else
-          ApiResponses.error(conn, :forbidden, "Insufficient permission")
+          {:error, changeset} ->
+            ApiResponses.changeset_error(conn, changeset)
         end
     end
   end

--- a/lib/streamshore_web/controllers/playlist_controller.ex
+++ b/lib/streamshore_web/controllers/playlist_controller.ex
@@ -1,104 +1,52 @@
 defmodule StreamshoreWeb.PlaylistController do
   use StreamshoreWeb, :controller
 
-  alias Streamshore.Guardian
   alias Streamshore.Playlists
   alias StreamshoreWeb.ApiResponses
 
-  def index(conn, params) do
-    params["user_id"]
+  plug StreamshoreWeb.Plugs.RequireAuth
+  plug StreamshoreWeb.Plugs.RequireNonAnon
+  plug StreamshoreWeb.Plugs.RequireCurrentUser, param: "user_id"
+
+  def index(conn, _params) do
+    conn.assigns.current_user
     |> Playlists.list_playlists()
     |> then(&ApiResponses.ok(conn, &1))
   end
 
-  def show(_conn, _params) do
-    # TODO: show playlist info
-  end
-
   def create(conn, params) do
-    case Guardian.get_user(Guardian.token_from_conn(conn)) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    case Playlists.create_playlist(conn.assigns.current_user, params) do
+      {:ok, _schema} ->
+        ApiResponses.ok(conn)
 
-      {:ok, user, anon} ->
-        cond do
-          anon ->
-            ApiResponses.error(conn, :forbidden, "You must be logged in to create a playlist")
-
-          user != params["user_id"] ->
-            ApiResponses.error(conn, :forbidden, "Insufficient permission")
-
-          true ->
-            case Playlists.create_playlist(params["user_id"], params) do
-              {:ok, _schema} ->
-                ApiResponses.ok(conn)
-
-              {:error, changeset} ->
-                ApiResponses.changeset_error(conn, changeset)
-            end
-        end
+      {:error, changeset} ->
+        ApiResponses.changeset_error(conn, changeset)
     end
   end
 
   def update(conn, params) do
-    case Guardian.get_user(Guardian.token_from_conn(conn)) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    case Playlists.update_playlist(conn.assigns.current_user, params["id"], params) do
+      {:ok, _schema} ->
+        ApiResponses.ok(conn)
 
-      {:ok, user, anon} ->
-        playlist = params["id"]
-        owner = params["user_id"]
+      {:error, :not_found} ->
+        ApiResponses.error(conn, :not_found, "Playlist does not exist")
 
-        cond do
-          anon ->
-            ApiResponses.error(conn, :forbidden, "You must be logged in to update a playlist")
-
-          user != owner ->
-            ApiResponses.error(conn, :forbidden, "Insufficient permission")
-
-          true ->
-            case Playlists.update_playlist(owner, playlist, params) do
-              {:ok, _schema} ->
-                ApiResponses.ok(conn)
-
-              {:error, :not_found} ->
-                ApiResponses.error(conn, :not_found, "Playlist doesn't exist")
-
-              {:error, changeset} ->
-                ApiResponses.changeset_error(conn, changeset)
-            end
-        end
+      {:error, changeset} ->
+        ApiResponses.changeset_error(conn, changeset)
     end
   end
 
   def delete(conn, params) do
-    case Guardian.get_user(Guardian.token_from_conn(conn)) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    case Playlists.delete_playlist(conn.assigns.current_user, params["id"]) do
+      {:ok, _schema} ->
+        ApiResponses.ok(conn)
 
-      {:ok, user, anon} ->
-        playlist = params["id"]
-        owner = params["user_id"]
+      {:error, :not_found} ->
+        ApiResponses.error(conn, :not_found, "Playlist does not exist")
 
-        cond do
-          anon ->
-            ApiResponses.error(conn, :forbidden, "You must be logged in to delete a playlist")
-
-          user != owner ->
-            ApiResponses.error(conn, :forbidden, "Insufficient permission")
-
-          true ->
-            case Playlists.delete_playlist(owner, playlist) do
-              {:error, :not_found} ->
-                ApiResponses.error(conn, :not_found, "Playlist doesn't exist")
-
-              {:ok, _schema} ->
-                ApiResponses.ok(conn)
-
-              {:error, changeset} ->
-                ApiResponses.changeset_error(conn, changeset)
-            end
-        end
+      {:error, changeset} ->
+        ApiResponses.changeset_error(conn, changeset)
     end
   end
 end

--- a/lib/streamshore_web/controllers/playlist_video_controller.ex
+++ b/lib/streamshore_web/controllers/playlist_video_controller.ex
@@ -1,95 +1,52 @@
 defmodule StreamshoreWeb.PlaylistVideoController do
   use StreamshoreWeb, :controller
 
-  alias Streamshore.Guardian
   alias Streamshore.Playlists
   alias StreamshoreWeb.ApiResponses
 
-  def index(conn, params) do
-    video_list = Playlists.list_playlist_videos(params["user_id"], params["playlist_id"])
-    ApiResponses.ok(conn, video_list)
-  end
+  plug StreamshoreWeb.Plugs.RequireAuth
+  plug StreamshoreWeb.Plugs.RequireNonAnon
+  plug StreamshoreWeb.Plugs.RequireCurrentUser, param: "user_id"
 
-  def show(_conn, _params) do
-    # TODO: show video info
+  def index(conn, params) do
+    Playlists.list_playlist_videos(conn.assigns.current_user, params["playlist_id"])
+    |> then(&ApiResponses.ok(conn, &1))
   end
 
   def create(conn, params) do
-    case Guardian.get_user(Guardian.token_from_conn(conn)) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    case Playlists.add_playlist_video(
+           conn.assigns.current_user,
+           params["playlist_id"],
+           params["video"]
+         ) do
+      {:ok, _schema} ->
+        ApiResponses.ok(conn)
 
-      {:ok, user, anon} ->
-        video = params["video"]
-        playlist = params["playlist_id"]
-        owner = params["user_id"]
+      {:error, :playlist_not_found} ->
+        ApiResponses.error(conn, :not_found, "Playlist does not exist")
 
-        cond do
-          anon ->
-            ApiResponses.error(
-              conn,
-              :forbidden,
-              "You must be logged in to add a video to a playlist"
-            )
+      {:error, :invalid_video} ->
+        ApiResponses.error(conn, :unprocessable_entity, "Invalid video")
 
-          user != owner ->
-            ApiResponses.error(conn, :forbidden, "Insufficient permission")
-
-          true ->
-            case Playlists.add_playlist_video(owner, playlist, video) do
-              {:ok, _schema} ->
-                ApiResponses.ok(conn)
-
-              {:error, :playlist_not_found} ->
-                ApiResponses.error(conn, :not_found, "Playlist doesn't exists")
-
-              {:error, :invalid_video} ->
-                ApiResponses.error(conn, :unprocessable_entity, "Invalid video")
-
-              {:error, changeset} ->
-                ApiResponses.changeset_error(conn, changeset)
-            end
-        end
+      {:error, changeset} ->
+        ApiResponses.changeset_error(conn, changeset)
     end
   end
 
-  def update(_conn, _params) do
-    # TODO: video edit action
-  end
-
   def delete(conn, params) do
-    case Guardian.get_user(Guardian.token_from_conn(conn)) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    case Playlists.delete_playlist_video(
+           conn.assigns.current_user,
+           params["playlist_id"],
+           params["id"]
+         ) do
+      {:ok, _schema} ->
+        ApiResponses.ok(conn)
 
-      {:ok, user, anon} ->
-        video = params["id"]
-        playlist = params["playlist_id"]
-        owner = params["user_id"]
+      {:error, :not_found} ->
+        ApiResponses.error(conn, :not_found, "Video does not exist in playlist")
 
-        cond do
-          anon ->
-            ApiResponses.error(
-              conn,
-              :forbidden,
-              "You must be logged in to delete a video from a playlist"
-            )
-
-          user != owner ->
-            ApiResponses.error(conn, :forbidden, "Insufficient permission")
-
-          true ->
-            case Playlists.delete_playlist_video(owner, playlist, video) do
-              {:error, :not_found} ->
-                ApiResponses.error(conn, :not_found, "Video doesn't exist in playlist")
-
-              {:ok, _schema} ->
-                ApiResponses.ok(conn)
-
-              {:error, changeset} ->
-                ApiResponses.changeset_error(conn, changeset)
-            end
-        end
+      {:error, changeset} ->
+        ApiResponses.changeset_error(conn, changeset)
     end
   end
 end

--- a/lib/streamshore_web/controllers/room_controller.ex
+++ b/lib/streamshore_web/controllers/room_controller.ex
@@ -2,11 +2,22 @@ defmodule StreamshoreWeb.RoomController do
   use StreamshoreWeb, :controller
 
   alias Streamshore.Events
-  alias Streamshore.Guardian
   alias Streamshore.PermissionLevel
   alias Streamshore.Rooms
   alias StreamshoreWeb.ApiResponses
   alias StreamshoreWeb.Presence
+
+  plug StreamshoreWeb.Plugs.RequireAuth
+  plug StreamshoreWeb.Plugs.RequireNonAnon when action in [:create, :edit, :update, :delete]
+
+  plug StreamshoreWeb.Plugs.LoadRoomPermission,
+       [param: "id"] when action in [:edit, :update, :delete]
+
+  plug StreamshoreWeb.Plugs.RequireRoomPermission,
+       [min: PermissionLevel.manager()] when action in [:edit, :update]
+
+  plug StreamshoreWeb.Plugs.RequireRoomPermission,
+       [min: PermissionLevel.owner()] when action in [:delete]
 
   def index(conn, params) do
     rooms =
@@ -35,92 +46,47 @@ defmodule StreamshoreWeb.RoomController do
   end
 
   def create(conn, params) do
-    case Guardian.get_user(Guardian.token_from_conn(conn)) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    case Rooms.create_room(conn.assigns.current_user, params) do
+      {:ok, room} ->
+        ApiResponses.ok(conn, %{route: room.route})
 
-      {:ok, user, anon} ->
-        case anon do
-          false ->
-            case Rooms.create_room(user, params) do
-              {:ok, room} ->
-                ApiResponses.ok(conn, %{route: room.route})
-
-              {:error, changeset} ->
-                ApiResponses.changeset_error(conn, changeset)
-            end
-
-          true ->
-            ApiResponses.error(conn, :forbidden, "You must be logged in to create a room")
-        end
+      {:error, changeset} ->
+        ApiResponses.changeset_error(conn, changeset)
     end
   end
 
   def edit(conn, params) do
-    case Guardian.get_user_and_permission(Guardian.token_from_conn(conn), params["id"]) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
-
-      {:ok, _user, _anon, permission} ->
-        if permission >= PermissionLevel.manager() do
-          case Rooms.settings(params["id"]) do
-            nil -> ApiResponses.error(conn, :not_found, "Room does not exist")
-            room -> ApiResponses.ok(conn, room)
-          end
-        else
-          ApiResponses.error(conn, :forbidden, "Insufficient permission")
-        end
+    case Rooms.settings(params["id"]) do
+      nil -> ApiResponses.error(conn, :not_found, "Room does not exist")
+      room -> ApiResponses.ok(conn, room)
     end
   end
 
   def update(conn, params) do
-    case Guardian.get_user_and_permission(Guardian.token_from_conn(conn), params["id"]) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    case Rooms.update_room(params["id"], params) do
+      {:ok, _room, events} ->
+        Events.dispatch_all(events)
+        ApiResponses.ok(conn)
 
-      {:ok, _user, _anon, permission} ->
-        if permission >= PermissionLevel.manager() do
-          room = params["id"]
+      {:error, :not_found} ->
+        ApiResponses.error(conn, :not_found, "Room does not exist")
 
-          case Rooms.update_room(room, params) do
-            {:error, :not_found} ->
-              ApiResponses.error(conn, :not_found, "Room does not exist")
-
-            {:ok, _room, events} ->
-              Events.dispatch_all(events)
-              ApiResponses.ok(conn)
-
-            {:error, changeset} ->
-              ApiResponses.changeset_error(conn, changeset)
-          end
-        else
-          ApiResponses.error(conn, :forbidden, "Insufficient permission")
-        end
+      {:error, changeset} ->
+        ApiResponses.changeset_error(conn, changeset)
     end
   end
 
   def delete(conn, params) do
-    case Guardian.get_user(Guardian.token_from_conn(conn)) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    case Rooms.delete_room(params["id"]) do
+      {:ok, _room, events} ->
+        Events.dispatch_all(events)
+        ApiResponses.ok(conn)
 
-      {:ok, user, _anon} ->
-        room_name = params["id"]
+      {:error, :not_found} ->
+        ApiResponses.error(conn, :not_found, "Room does not exist")
 
-        case Rooms.delete_owned_room(room_name, user) do
-          {:error, :not_found} ->
-            ApiResponses.error(conn, :not_found, "Room does not exist")
-
-          {:error, :forbidden} ->
-            ApiResponses.error(conn, :forbidden, "Insufficient permission")
-
-          {:ok, _room, events} ->
-            Events.dispatch_all(events)
-            ApiResponses.ok(conn)
-
-          {:error, changeset} ->
-            ApiResponses.changeset_error(conn, changeset)
-        end
+      {:error, changeset} ->
+        ApiResponses.changeset_error(conn, changeset)
     end
   end
 

--- a/lib/streamshore_web/controllers/session_controller.ex
+++ b/lib/streamshore_web/controllers/session_controller.ex
@@ -27,8 +27,8 @@ defmodule StreamshoreWeb.SessionController do
     end
   end
 
-  def delete(conn, params) do
-    Guardian.revoke(params["id"])
+  def delete(conn, _params) do
+    Guardian.revoke(conn.assigns.current_token)
     ApiResponses.ok(conn)
   end
 end

--- a/lib/streamshore_web/controllers/session_controller.ex
+++ b/lib/streamshore_web/controllers/session_controller.ex
@@ -1,42 +1,29 @@
 defmodule StreamshoreWeb.SessionController do
   use StreamshoreWeb, :controller
-  import Dictionary
 
   alias Streamshore.Accounts
-  alias Streamshore.AuthTokens
   alias Streamshore.Guardian
   alias StreamshoreWeb.ApiResponses
 
   def create(conn, params) do
-    if Enum.count(params) != 0 do
-      user = Accounts.get_by_email_or_username(params["id"])
+    case map_size(params) do
+      0 ->
+        case Accounts.create_anonymous_session() do
+          {:ok, session} ->
+            ApiResponses.ok(conn, session)
+        end
 
-      if user && Pbkdf2.verify_pass(params["password"], user.password) do
-        case user.verify_token do
-          nil ->
-            ApiResponses.ok(conn, %{
-              token: AuthTokens.create_token(user.username, false),
-              user: user.username,
-              anon: false
-            })
+      _ ->
+        case Accounts.create_authenticated_session(params["id"], params["password"]) do
+          {:ok, session} ->
+            ApiResponses.ok(conn, session)
 
-          _ ->
+          {:error, :invalid_credentials} ->
+            ApiResponses.error(conn, :unauthorized, "Invalid credentials")
+
+          {:error, :email_not_verified} ->
             ApiResponses.error(conn, :forbidden, "Email address not verified")
         end
-      else
-        ApiResponses.error(conn, :unauthorized, "Invalid credentials")
-      end
-    else
-      username =
-        String.capitalize(String.trim(random_adjective(), "\r")) <>
-          String.capitalize(String.trim(random_adjective(), "\r")) <>
-          String.capitalize(String.trim(random_animal(), "\r"))
-
-      ApiResponses.ok(conn, %{
-        token: AuthTokens.create_token(username, true),
-        user: username,
-        anon: true
-      })
     end
   end
 

--- a/lib/streamshore_web/controllers/user_controller.ex
+++ b/lib/streamshore_web/controllers/user_controller.ex
@@ -3,21 +3,15 @@ defmodule StreamshoreWeb.UserController do
 
   alias Streamshore.Accounts
   alias Streamshore.Events
-  alias Streamshore.Guardian
   alias StreamshoreWeb.ApiResponses
 
-  def index(conn, _params) do
-    case Guardian.get_user_and_admin(Guardian.token_from_conn(conn)) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+  plug StreamshoreWeb.Plugs.RequireAuth when action in [:index, :show, :update, :delete]
+  plug StreamshoreWeb.Plugs.RequireNonAnon when action in [:index, :update, :delete]
+  plug StreamshoreWeb.Plugs.RequireAdmin when action in [:index]
+  plug StreamshoreWeb.Plugs.RequireCurrentUser, [param: "id"] when action in [:delete]
 
-      {:ok, _user, _anon, admin} ->
-        if admin do
-          ApiResponses.ok(conn, Accounts.list_users())
-        else
-          ApiResponses.error(conn, :forbidden, "Insufficient permission")
-        end
-    end
+  def index(conn, _params) do
+    ApiResponses.ok(conn, Accounts.list_users())
   end
 
   def create(conn, params) do
@@ -61,53 +55,43 @@ defmodule StreamshoreWeb.UserController do
   end
 
   def delete(conn, params) do
-    case Guardian.get_user(Guardian.token_from_conn(conn)) do
-      {:ok, user, anon} ->
-        username = params["id"]
+    username = params["id"]
 
-        if user == username && !anon do
-          case Accounts.delete_user(username) do
-            {:ok, _schema, events} ->
-              Events.dispatch_all(events)
-              ApiResponses.ok(conn)
+    case Accounts.delete_user(username) do
+      {:ok, _schema, events} ->
+        Events.dispatch_all(events)
+        ApiResponses.ok(conn)
 
-            {:error, :not_found} ->
-              ApiResponses.error(conn, :not_found, "User not found")
+      {:error, :not_found} ->
+        ApiResponses.error(conn, :not_found, "User not found")
 
-            {:error, changeset} ->
-              ApiResponses.changeset_error(conn, changeset)
-          end
-        else
-          ApiResponses.error(conn, :forbidden, "Insufficient permission")
-        end
-
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+      {:error, changeset} ->
+        ApiResponses.changeset_error(conn, changeset)
     end
   end
 
   defp handle_resend_verification(conn, params) do
     case Accounts.resend_verification_email(params["id"]) do
+      {:ok, _schema, events} ->
+        Events.dispatch_all(events)
+        ApiResponses.ok(conn)
+
       {:error, :not_found} ->
         ApiResponses.error(conn, :not_found, "User not found")
 
       {:error, :already_verified} ->
         ApiResponses.error(conn, :conflict, "Email already verified")
-
-      {:ok, _schema, events} ->
-        Events.dispatch_all(events)
-        ApiResponses.ok(conn)
     end
   end
 
   defp handle_password_reset_request(conn, params) do
-    case Accounts.store_reset_token(params["id"]) do
-      {:error, :not_found} ->
-        ApiResponses.error(conn, :not_found, "User not found")
-
+    case Accounts.request_password_reset(params["id"]) do
       {:ok, _schema, events} ->
         Events.dispatch_all(events)
         ApiResponses.ok(conn)
+
+      {:error, :not_found} ->
+        ApiResponses.error(conn, :not_found, "User not found")
 
       {:error, changeset} ->
         ApiResponses.changeset_error(conn, changeset)
@@ -116,6 +100,9 @@ defmodule StreamshoreWeb.UserController do
 
   defp handle_verify_email(conn, params) do
     case Accounts.verify_email(params["id"], params["verify_token"]) do
+      {:ok, _schema} ->
+        ApiResponses.ok(conn)
+
       {:error, :not_found} ->
         ApiResponses.error(conn, :not_found, "User not found")
 
@@ -125,42 +112,33 @@ defmodule StreamshoreWeb.UserController do
       {:error, :invalid_token} ->
         ApiResponses.error(conn, :unauthorized, "Invalid token")
 
-      {:ok, _schema} ->
-        ApiResponses.ok(conn)
-
       {:error, changeset} ->
         ApiResponses.changeset_error(conn, changeset)
     end
   end
 
   defp handle_password_update(conn, params) do
-    token = Guardian.token_from_conn(conn)
+    username = params["id"]
 
-    case Guardian.get_user(token) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    result =
+      if username == conn.assigns.current_user do
+        Accounts.update_password(username, params["password"])
+      else
+        Accounts.reset_password(username, conn.assigns.current_token, params["password"])
+      end
 
-      {:ok, user, anon} ->
-        username = params["id"]
+    case result do
+      {:ok, _schema} ->
+        ApiResponses.ok(conn)
 
-        if !anon do
-          if user == username || Accounts.valid_reset_token?(username, token) do
-            case Accounts.update_password(username, params["password"]) do
-              {:ok, _schema} ->
-                ApiResponses.ok(conn)
+      {:error, :not_found} ->
+        ApiResponses.error(conn, :not_found, "User not found")
 
-              {:error, :not_found} ->
-                ApiResponses.error(conn, :not_found, "User not found")
+      {:error, :invalid_token} ->
+        ApiResponses.error(conn, :forbidden, "Insufficient permission")
 
-              {:error, changeset} ->
-                ApiResponses.changeset_error(conn, changeset)
-            end
-          else
-            ApiResponses.error(conn, :forbidden, "Insufficient permission")
-          end
-        else
-          ApiResponses.error(conn, :forbidden, "Insufficient permission")
-        end
+      {:error, changeset} ->
+        ApiResponses.changeset_error(conn, changeset)
     end
   end
 end

--- a/lib/streamshore_web/controllers/video_controller.ex
+++ b/lib/streamshore_web/controllers/video_controller.ex
@@ -1,68 +1,52 @@
 defmodule StreamshoreWeb.VideoController do
   use StreamshoreWeb, :controller
 
-  alias Streamshore.Guardian
   alias Streamshore.PermissionLevel
   alias Streamshore.QueueManager
   alias Streamshore.Rooms
   alias StreamshoreWeb.ApiResponses
 
+  plug StreamshoreWeb.Plugs.RequireAuth
+  plug StreamshoreWeb.Plugs.LoadRoomPermission
+
+  plug StreamshoreWeb.Plugs.RequireRoomPermission,
+       [min: PermissionLevel.user()] when action in [:create]
+
+  plug StreamshoreWeb.Plugs.RequireRoomPermission,
+       [min: PermissionLevel.manager()] when action in [:update, :delete]
+
   def create(conn, params) do
     room = params["room_id"]
+    user = conn.assigns.current_user
 
-    case Guardian.get_user_and_permission(Guardian.token_from_conn(conn), room) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
+    cond do
+      conn.assigns.current_room_permission < Rooms.queue_perm(room) ->
+        ApiResponses.error(conn, :forbidden, "Insufficient permission")
 
-      {:ok, user, anon, perm} ->
-        if perm >= Rooms.queue_perm(room) do
-          if Rooms.anon_queue?(room) || !anon do
-            case QueueManager.add_to_queue(room, params["id"], user) do
-              :ok ->
-                ApiResponses.ok(conn)
+      !Rooms.anon_queue?(room) && conn.assigns.current_anon ->
+        ApiResponses.error(conn, :forbidden, "You must be logged in to perform this action")
 
-              {:error, :queue_limit, error} ->
-                ApiResponses.error(conn, :conflict, error)
+      true ->
+        case QueueManager.add_to_queue(room, params["id"], user) do
+          :ok ->
+            ApiResponses.ok(conn)
 
-              {:error, :invalid_video, error} ->
-                ApiResponses.error(conn, :unprocessable_entity, error)
-            end
-          else
-            ApiResponses.error(conn, :forbidden, "You must be logged in to submit a video")
-          end
-        else
-          ApiResponses.error(conn, :forbidden, "Insufficient permission")
+          {:error, :queue_limit, error} ->
+            ApiResponses.error(conn, :conflict, error)
+
+          {:error, :invalid_video, error} ->
+            ApiResponses.error(conn, :unprocessable_entity, error)
         end
     end
   end
 
   def update(conn, params) do
-    case Guardian.get_user_and_permission(Guardian.token_from_conn(conn), params["room_id"]) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
-
-      {:ok, _user, _anon, perm} ->
-        if perm >= PermissionLevel.manager() do
-          QueueManager.move_to_front(params["room_id"], params["id"])
-          ApiResponses.ok(conn)
-        else
-          ApiResponses.error(conn, :forbidden, "Insufficient permission")
-        end
-    end
+    QueueManager.move_to_front(params["room_id"], params["id"])
+    ApiResponses.ok(conn)
   end
 
   def delete(conn, params) do
-    case Guardian.get_user_and_permission(Guardian.token_from_conn(conn), params["room_id"]) do
-      {:error, error} ->
-        ApiResponses.error(conn, :unauthorized, error)
-
-      {:ok, _user, _anon, perm} ->
-        if perm >= PermissionLevel.manager() do
-          QueueManager.remove_from_queue(params["room_id"], params["id"])
-          ApiResponses.ok(conn)
-        else
-          ApiResponses.error(conn, :forbidden, "Insufficient permission")
-        end
-    end
+    QueueManager.remove_from_queue(params["room_id"], params["id"])
+    ApiResponses.ok(conn)
   end
 end

--- a/lib/streamshore_web/events/room_events.ex
+++ b/lib/streamshore_web/events/room_events.ex
@@ -8,4 +8,8 @@ defmodule StreamshoreWeb.RoomEvents do
   def dispatch({:room_updated, route, payload}) do
     Endpoint.broadcast("room:" <> route, "update", payload)
   end
+
+  def dispatch({:permission_updated, route, payload}) do
+    Endpoint.broadcast("room:" <> route, "permission", payload)
+  end
 end

--- a/lib/streamshore_web/router.ex
+++ b/lib/streamshore_web/router.ex
@@ -3,6 +3,7 @@ defmodule StreamshoreWeb.Router do
 
   pipeline :api do
     plug :accepts, ["json"]
+    plug StreamshoreWeb.Plugs.LoadAuth
   end
 
   scope "/api", StreamshoreWeb do
@@ -14,8 +15,8 @@ defmodule StreamshoreWeb.Router do
       resources "/friends", FriendController, only: [:index, :create, :update, :delete]
       resources "/favorites", FavoriteController, only: [:index, :show, :create, :delete]
 
-      resources "/playlists", PlaylistController, except: [:new, :edit] do
-        resources "/videos", PlaylistVideoController, only: [:index, :create, :update, :delete]
+      resources "/playlists", PlaylistController, only: [:index, :create, :update, :delete] do
+        resources "/videos", PlaylistVideoController, only: [:index, :create, :delete]
       end
     end
 

--- a/test/streamshore/accounts_test.exs
+++ b/test/streamshore/accounts_test.exs
@@ -52,6 +52,56 @@ defmodule Streamshore.AccountsTest do
     assert event_user.verify_token == user.verify_token
   end
 
+  test "create_authenticated_session returns a session payload for a verified user" do
+    Application.put_env(:streamshore, :mailer_enabled, true)
+    Application.put_env(:streamshore, :mailer_from_address, "noreply@example.com")
+
+    assert {:ok, _user, _events} =
+             Accounts.create_user(%{
+               "email" => "session@test.com",
+               "username" => "session-user",
+               "password" => "$Test123"
+             })
+
+    user = Repo.get_by!(User, username: "session-user")
+    assert {:ok, _verified_user} = Accounts.verify_email("session-user", user.verify_token)
+
+    assert {:ok, session} =
+             Accounts.create_authenticated_session("session-user", "$Test123")
+
+    assert session.user == "session-user"
+    assert session.anon == false
+    assert is_binary(session.token)
+  end
+
+  test "create_authenticated_session rejects invalid credentials" do
+    assert {:error, :invalid_credentials} =
+             Accounts.create_authenticated_session("missing-user", "$Test123")
+  end
+
+  test "create_authenticated_session rejects unverified users" do
+    Application.put_env(:streamshore, :mailer_enabled, true)
+    Application.put_env(:streamshore, :mailer_from_address, "noreply@example.com")
+
+    assert {:ok, _user, _events} =
+             Accounts.create_user(%{
+               "email" => "unverified@test.com",
+               "username" => "unverified-user",
+               "password" => "$Test123"
+             })
+
+    assert {:error, :email_not_verified} =
+             Accounts.create_authenticated_session("unverified-user", "$Test123")
+  end
+
+  test "create_anonymous_session returns an anonymous session payload" do
+    assert {:ok, session} = Accounts.create_anonymous_session()
+
+    assert session.user
+    assert session.anon == true
+    assert is_binary(session.token)
+  end
+
   test "verify_email clears the stored verification token" do
     Application.put_env(:streamshore, :mailer_enabled, true)
     Application.put_env(:streamshore, :mailer_from_address, "noreply@example.com")
@@ -92,6 +142,32 @@ defmodule Streamshore.AccountsTest do
     assert event_user.username == resent_user.username
   end
 
+  test "resend_verification_email invalidates the previous verification token" do
+    Application.put_env(:streamshore, :mailer_enabled, true)
+    Application.put_env(:streamshore, :mailer_from_address, "noreply@example.com")
+
+    assert {:ok, _user, _events} =
+             Accounts.create_user(%{
+               "email" => "rotated-verify@test.com",
+               "username" => "rotated-verify-user",
+               "password" => "$Test123"
+             })
+
+    original_token = Repo.get_by!(User, username: "rotated-verify-user").verify_token
+
+    assert {:ok, resent_user, [{:send_verification_email, _event_user}]} =
+             Accounts.resend_verification_email("rotated-verify-user")
+
+    refute resent_user.verify_token == original_token
+    assert {:error, :invalid_token} =
+             Accounts.verify_email("rotated-verify-user", original_token)
+
+    assert {:ok, verified_user} =
+             Accounts.verify_email("rotated-verify-user", resent_user.verify_token)
+
+    assert verified_user.verify_token == nil
+  end
+
   test "resend_verification_email returns already_verified for verified user" do
     assert {:ok, _user, _events} =
              Accounts.create_user(%{
@@ -103,7 +179,7 @@ defmodule Streamshore.AccountsTest do
     assert {:error, :already_verified} = Accounts.resend_verification_email("already-verified")
   end
 
-  test "store_reset_token saves a reset token for the user" do
+  test "request_password_reset saves a reset token for the user" do
     assert {:ok, _user, _events} =
              Accounts.create_user(%{
                "email" => "reset@test.com",
@@ -112,11 +188,26 @@ defmodule Streamshore.AccountsTest do
              })
 
     assert {:ok, updated_user, [{:send_password_reset_email, event_user, token}]} =
-             Accounts.store_reset_token("reset@test.com")
+             Accounts.request_password_reset("reset@test.com")
 
     assert updated_user.reset_token != nil
     assert Repo.get_by!(User, username: "reset-user").reset_token != nil
     assert event_user.username == updated_user.username
+    assert token == updated_user.reset_token
+  end
+
+  test "request_password_reset accepts a username identifier" do
+    assert {:ok, _user, _events} =
+             Accounts.create_user(%{
+               "email" => "username-reset@test.com",
+               "username" => "username-reset-user",
+               "password" => "$Test123"
+             })
+
+    assert {:ok, updated_user, [{:send_password_reset_email, _event_user, token}]} =
+             Accounts.request_password_reset("username-reset-user")
+
+    assert updated_user.username == "username-reset-user"
     assert token == updated_user.reset_token
   end
 
@@ -128,12 +219,63 @@ defmodule Streamshore.AccountsTest do
                "password" => "$Test123"
              })
 
-    assert {:ok, _user, _events} = Accounts.store_reset_token("password@test.com")
+    assert {:ok, _user, _events} = Accounts.request_password_reset("password@test.com")
     assert {:ok, updated_user} = Accounts.update_password("password-user", "$NewPass123")
 
     assert updated_user.password != "$NewPass123"
     assert updated_user.reset_token == nil
     assert Repo.get_by!(User, username: "password-user").reset_token == nil
+  end
+
+  test "reset_password updates the password with a stored reset token" do
+    assert {:ok, _user, _events} =
+             Accounts.create_user(%{
+               "email" => "reset-flow@test.com",
+               "username" => "reset-flow-user",
+               "password" => "$Test123"
+             })
+
+    assert {:ok, _user, [{:send_password_reset_email, _event_user, token}]} =
+             Accounts.request_password_reset("reset-flow@test.com")
+
+    assert {:ok, updated_user} =
+             Accounts.reset_password("reset-flow-user", token, "$NewPass123")
+
+    assert updated_user.password != "$NewPass123"
+    assert updated_user.reset_token == nil
+    assert Repo.get_by!(User, username: "reset-flow-user").reset_token == nil
+  end
+
+  test "reset_password rejects an invalid stored reset token" do
+    assert {:ok, _user, _events} =
+             Accounts.create_user(%{
+               "email" => "invalid-reset@test.com",
+               "username" => "invalid-reset-user",
+               "password" => "$Test123"
+             })
+
+    assert {:ok, _user, _events} = Accounts.request_password_reset("invalid-reset@test.com")
+
+    assert {:error, :invalid_token} =
+             Accounts.reset_password("invalid-reset-user", "forged-token", "$NewPass123")
+  end
+
+  test "reset_password consumes the stored reset token after use" do
+    assert {:ok, _user, _events} =
+             Accounts.create_user(%{
+               "email" => "single-use-reset@test.com",
+               "username" => "single-use-reset-user",
+               "password" => "$Test123"
+             })
+
+    assert {:ok, _user, [{:send_password_reset_email, _event_user, token}]} =
+             Accounts.request_password_reset("single-use-reset@test.com")
+
+    assert {:ok, _updated_user} =
+             Accounts.reset_password("single-use-reset-user", token, "$NewPass123")
+
+    assert {:error, :invalid_token} =
+             Accounts.reset_password("single-use-reset-user", token, "$AnotherPass123")
   end
 
   test "delete_user removes owned room references" do

--- a/test/streamshore/rooms_test.exs
+++ b/test/streamshore/rooms_test.exs
@@ -54,7 +54,7 @@ defmodule Streamshore.RoomsTest do
     assert Repo.get_by!(Room, route: "owned-room").motd == "Updated"
   end
 
-  test "delete_owned_room removes favorites and permissions" do
+  test "delete_room removes favorites and permissions" do
     assert {:ok, room} =
              Rooms.create_room("owner-user", %{
                "name" => "Owned Room",
@@ -72,8 +72,8 @@ defmodule Streamshore.RoomsTest do
       })
     )
 
-    assert {:ok, _room, [{:room_deleted, "owned-room"}]} =
-             Rooms.delete_owned_room(room.route, "owner-user")
+    assert {:ok, "owned-room", [{:room_deleted, "owned-room"}]} =
+             Rooms.delete_room(room.route)
 
     assert Repo.get_by(Room, route: room.route) == nil
     assert Repo.get_by(Favorites, room: room.route) == nil
@@ -121,16 +121,5 @@ defmodule Streamshore.RoomsTest do
     assert Repo.get_by(Favorites, room: room_two.route) == nil
     assert Repo.get_by(Permission, room: room_one.route) == nil
     assert Repo.get_by(Permission, room: room_two.route) == nil
-  end
-
-  test "delete_owned_room returns forbidden for non-owner" do
-    assert {:ok, room} =
-             Rooms.create_room("owner-user", %{
-               "name" => "Owned Room",
-               "motd" => "",
-               "privacy" => 0
-             })
-
-    assert {:error, :forbidden} = Rooms.delete_owned_room(room.route, "other-user")
   end
 end

--- a/test/streamshore_web/controllers/favorites_controller_test.exs
+++ b/test/streamshore_web/controllers/favorites_controller_test.exs
@@ -64,6 +64,34 @@ defmodule FavoritesControllerTest do
     assert json_response(conn, 403) == %{"error" => "Insufficient permission"}
   end
 
+  test "Adding a favorite without a token returns unauthorized" do
+    conn =
+      post(build_conn(), Routes.user_favorite_path(build_conn(), :create, "user"), %{
+        room: "Create"
+      })
+
+    assert json_response(conn, 401) == %{"error" => "No valid token provided"}
+  end
+
+  test "Anonymous users cannot add favorites", %{conn: conn} do
+    conn = post(conn, Routes.room_path(conn, :create), %{name: "Create", motd: "", privacy: 0})
+    assert json_response(conn, 200) == %{"route" => "create"}
+
+    {:ok, token, _claims} = Guardian.encode_and_sign("anon-user", %{anon: true})
+
+    anon_conn =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token)
+
+    anon_conn =
+      post(anon_conn, Routes.user_favorite_path(anon_conn, :create, "anon-user"), %{
+        room: "Create"
+      })
+
+    assert json_response(anon_conn, 403) ==
+             %{"error" => "Insufficient permission"}
+  end
+
   test "Adding a duplicate favorite returns conflict", %{conn: conn} do
     username = "user"
 

--- a/test/streamshore_web/controllers/friends_controller_test.exs
+++ b/test/streamshore_web/controllers/friends_controller_test.exs
@@ -151,7 +151,7 @@ defmodule FriendsControllerTest do
     assert json_response(conn2, 200) == %{}
     # get friends of 3rd user
     conn = get(conn, Routes.user_friend_path(conn, :index, tester3))
-    assert json_response(conn, 200) == %{"friends" => [], "requests" => []}
+    assert json_response(conn, 403) == %{"error" => "Insufficient permission"}
   end
 
   test "Getting a list of nicknames", %{conn: conn} do

--- a/test/streamshore_web/controllers/permission_controller_test.exs
+++ b/test/streamshore_web/controllers/permission_controller_test.exs
@@ -76,6 +76,17 @@ defmodule PermissionControllerTest do
     assert json_response(manager_conn, 403) == %{"error" => "Insufficient permission"}
   end
 
+  test "permission update without a token returns unauthorized" do
+    conn =
+      put(
+        build_conn(),
+        Routes.room_permission_path(build_conn(), :show, "permissions", "other-user"),
+        %{permission: PermissionLevel.manager()}
+      )
+
+    assert json_response(conn, 401) == %{"error" => "No valid token provided"}
+  end
+
   test "set permission", %{conn: conn} do
     conn
     |> put(Routes.room_permission_path(conn, :show, "permissions", "set-user"), %{

--- a/test/streamshore_web/controllers/user_controller_test.exs
+++ b/test/streamshore_web/controllers/user_controller_test.exs
@@ -119,13 +119,41 @@ defmodule UserControllerTest do
   end
 
   test "Updating password without a token returns unauthorized", %{conn: _conn} do
-    conn = put(build_conn(), Routes.user_path(build_conn(), :update, "user"), %{password: "$NewPass123"})
+    conn =
+      put(build_conn(), Routes.user_path(build_conn(), :update, "user"), %{
+        password: "$NewPass123"
+      })
 
     assert json_response(conn, 401) == %{"error" => "No valid token provided"}
   end
 
+  test "Anonymous users cannot update passwords", %{conn: conn} do
+    username = "anon-reset-user"
+
+    conn =
+      post(conn, Routes.user_path(conn, :create), %{
+        email: "anon-reset@test.com",
+        username: username,
+        password: "$Test123"
+      })
+
+    assert json_response(conn, 200) == %{}
+
+    {:ok, token, _claims} = Guardian.encode_and_sign("anon-user", %{anon: true})
+
+    anon_conn =
+      build_conn()
+      |> put_req_header("authorization", "Bearer " <> token)
+
+    anon_conn =
+      put(anon_conn, Routes.user_path(anon_conn, :update, username), %{password: "$NewPass123"})
+
+    assert json_response(anon_conn, 403) == %{"error" => "Insufficient permission"}
+  end
+
   test "Resending verification for an unknown user returns not found", %{conn: conn} do
-    conn = put(conn, Routes.user_path(conn, :update, "missing-user"), %{resend_verification: true})
+    conn =
+      put(conn, Routes.user_path(conn, :update, "missing-user"), %{resend_verification: true})
 
     assert json_response(conn, 404) == %{"error" => "User not found"}
   end
@@ -167,20 +195,24 @@ defmodule UserControllerTest do
 
     user = Accounts.get_by_email_or_username(username)
 
-    conn = put(conn, Routes.user_path(conn, :update, username), %{verify_token: user.verify_token})
+    conn =
+      put(conn, Routes.user_path(conn, :update, username), %{verify_token: user.verify_token})
+
     assert json_response(conn, 200) == %{}
 
-    conn = put(conn, Routes.user_path(conn, :update, username), %{verify_token: user.verify_token})
+    conn =
+      put(conn, Routes.user_path(conn, :update, username), %{verify_token: user.verify_token})
 
     assert json_response(conn, 409) == %{"error" => "Email already verified"}
   end
 
   test "Requesting a password reset for an unknown user returns not found", %{conn: conn} do
-    conn = put(conn, Routes.user_path(conn, :update, "missing@example.com"), %{reset_password: true})
+    conn =
+      put(conn, Routes.user_path(conn, :update, "missing@example.com"), %{reset_password: true})
 
     assert json_response(conn, 404) == %{"error" => "User not found"}
   end
-  
+
   test "Updating password with a stored reset token", %{conn: conn} do
     username = "reset-user"
 
@@ -194,7 +226,7 @@ defmodule UserControllerTest do
     assert json_response(conn, 200) == %{}
 
     assert {:ok, _updated_user, [{:send_password_reset_email, _event_user, token}]} =
-             Accounts.store_reset_token("reset@test.com")
+             Accounts.request_password_reset("reset@test.com")
 
     reset_conn =
       build_conn()
@@ -327,5 +359,11 @@ defmodule UserControllerTest do
   test "Getting list of all users as non-admin", %{conn: conn} do
     conn = get(conn, Routes.user_path(conn, :index))
     assert json_response(conn, 403) == %{"error" => "Insufficient permission"}
+  end
+
+  test "Getting list of all users without a token returns unauthorized" do
+    conn = get(build_conn(), Routes.user_path(build_conn(), :index))
+
+    assert json_response(conn, 401) == %{"error" => "No valid token provided"}
   end
 end

--- a/test/streamshore_web/controllers/video_controller_test.exs
+++ b/test/streamshore_web/controllers/video_controller_test.exs
@@ -103,6 +103,17 @@ defmodule VideoControllerTest do
     assert json_response(conn, 403) == %{"error" => "Insufficient permission"}
   end
 
+  test "video queue update without a token returns unauthorized", %{conn: conn} do
+    conn =
+      post(conn, Routes.room_path(conn, :create), %{name: "UpdateAuth", motd: "", privacy: 0})
+
+    assert json_response(conn, 200) == %{"route" => "updateauth"}
+
+    conn = put(build_conn(), Routes.room_video_path(build_conn(), :update, "updateauth", "0"))
+
+    assert json_response(conn, 401) == %{"error" => "No valid token provided"}
+  end
+
   test "queue limit returns conflict", %{conn: conn} do
     conn =
       post(conn, Routes.room_path(conn, :create), %{
@@ -145,7 +156,10 @@ defmodule VideoControllerTest do
 
     id = "_-k6ppRkpcM"
     conn2 = post(conn2, Routes.room_video_path(conn2, :create, "queueanon"), %{id: id})
-    assert json_response(conn2, 403) == %{"error" => "You must be logged in to submit a video"}
+
+    assert json_response(conn2, 403) == %{
+             "error" => "You must be logged in to perform this action"
+           }
   end
 
   test "votes tracked", %{conn: conn} do


### PR DESCRIPTION
## Summary

This PR continues the controller/context modernization work by thinning the web layer around auth and permission handling, moving more token-sensitive behavior into shared domain modules, and tightening the surrounding tests.

The API shape stays mostly the same. The goal here is to make the current behavior easier to reason about before larger playback or schema work.

## Main Changes

- added request-level auth loading in the API pipeline
- introduced shared auth/authorization plugs for:
  - required auth
  - non-anonymous access
  - current-user enforcement
  - admin enforcement
  - room-permission loading and enforcement
- updated controllers to rely on those plugs instead of direct `Guardian` checks
- moved more auth/session/reset behavior behind `Accounts`
- moved room-permission updates and related events behind `Rooms`
- switched permission updates to dispatch normal events rather than broadcasting directly from the controller
- aligned route declarations with the controller actions that are actually supported
- replaced the remaining sleep-based assertions in `VideoControllerTest` with deterministic polling
- added targeted auth and permission regression coverage

## Why

This is meant to cover the remaining Phase 1 / Phase 2 modernization work around:

- reducing web-layer overreach in auth-sensitive flows
- centralizing reusable authorization checks
- making auth and permission behavior more consistent across controllers
- hardening tests around security-sensitive paths and queue behavior

## Notable Behavior / Boundary Changes

- authenticated session creation now goes through `Accounts.create_authenticated_session/2`
- anonymous session creation now goes through `Accounts.create_anonymous_session/0`
- password reset requests now go through `Accounts.request_password_reset/1`
- password reset completion now validates against the stored reset token via `Accounts.reset_password/3`
- verification resend rotates the stored verification token
- reset tokens are now covered as single-use in tests
- room permission updates flow through `Rooms.update_permission/3`

## Testing

Ran locally:

- `mix test test/streamshore/accounts_test.exs`
- `mix test test/streamshore/accounts_test.exs test/streamshore/rooms_test.exs test/streamshore_web/controllers/user_controller_test.exs test/streamshore_web/controllers/permission_controller_test.exs test/streamshore_web/controllers/video_controller_test.exs test/streamshore_web/controllers/favorites_controller_test.exs test/streamshore_web/controllers/friends_controller_test.exs`

## Follow-up

`UserController.update/2` still multiplexes several auth-related actions behind one update route.

That is intentionally left in place for now. We agreed to keep the current shape because it gives us a cleaner path to split those actions into distinct routes later without mixing that API change into this boundary-cleanup PR.

In other words: the sensitive token validation and persistence behavior has already moved down into `Accounts`, but the route/action split is still outstanding and should come in a follow-up PR.